### PR TITLE
feat: migrate SQLite to Supabase PostgreSQL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Supabase PostgreSQL — Transaction pooler (port 6543) for app runtime
+DATABASE_URL=postgresql://postgres.[ref]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres
+
+# Supabase PostgreSQL — Direct connection (port 5432) for Drizzle Kit schema push
+DATABASE_URL_DIRECT=postgresql://postgres.[ref]:[password]@db.[ref].supabase.com:5432/postgres
+
+# Anthropic API key (required for PDF import feature)
+ANTHROPIC_API_KEY=sk-ant-...

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Personal retirement readiness dashboard — "Am I on track to retire?"
 
 ## Stack
 - Next.js 15 (App Router, TypeScript strict)
-- SQLite + Drizzle ORM (dev) → Supabase PostgreSQL (prod, M4)
+- Supabase PostgreSQL + Drizzle ORM (postgres-js driver)
 - Tailwind CSS + shadcn/ui
 - Recharts (charts)
 - Vitest (testing)
@@ -15,7 +15,7 @@ Personal retirement readiness dashboard — "Am I on track to retire?"
 - `npm run lint` — ESLint
 - `npm run typecheck` — TypeScript strict check
 - `npm test` — Vitest
-- `npm run db:push` — push Drizzle schema to SQLite
+- `npm run db:push` — push Drizzle schema to Supabase PostgreSQL
 - `npm run db:studio` — Drizzle Studio GUI
 
 ## File Organization

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -3,8 +3,8 @@ import { defineConfig } from 'drizzle-kit';
 export default defineConfig({
   schema: './src/lib/db/schema.ts',
   out: './drizzle',
-  dialect: 'sqlite',
+  dialect: 'postgresql',
   dbCredentials: {
-    url: './data/retireview.db',
+    url: process.env.DATABASE_URL_DIRECT!,
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
-        "better-sqlite3": "^12.6.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.1",
@@ -17,6 +16,7 @@
         "nanoid": "^5.1.6",
         "next": "16.1.6",
         "pdf-parse": "^2.4.5",
+        "postgres": "^3.4.8",
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -28,7 +28,6 @@
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
-        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -5771,16 +5770,6 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "node_modules/@types/better-sqlite3": {
-      "version": "7.6.13",
-      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
-      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -5887,7 +5876,7 @@
       "version": "20.19.35",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
       "integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -7043,26 +7032,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -7075,20 +7044,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/better-sqlite3": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
-      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
-      },
-      "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
-      }
-    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -7097,26 +7052,6 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/body-parser": {
@@ -7200,30 +7135,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -7365,12 +7276,6 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
-    },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
@@ -7965,21 +7870,6 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/dedent": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
@@ -7993,15 +7883,6 @@
         "babel-plugin-macros": {
           "optional": true
         }
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -8125,6 +8006,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -8383,15 +8265,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -9240,15 +9113,6 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -9453,12 +9317,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -9580,12 +9438,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "11.3.3",
@@ -9823,12 +9675,6 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -10120,26 +9966,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -10201,12 +10027,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -11626,18 +11447,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -11665,16 +11474,11 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -11769,12 +11573,6 @@
       "engines": {
         "node": "^18 || >=20"
       }
-    },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
     },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
@@ -11906,30 +11704,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/node-abi": {
-      "version": "3.87.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
-      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-abi/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/node-domexception": {
@@ -12189,6 +11963,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -12599,6 +12374,19 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/postgres": {
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.8.tgz",
+      "integrity": "sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/porsager"
+      }
+    },
     "node_modules/powershell-utils": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
@@ -12610,33 +12398,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/prelude-ls": {
@@ -12767,16 +12528,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -12929,30 +12680,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/react": {
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
@@ -13080,20 +12807,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/recast": {
@@ -13447,26 +13160,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -13927,51 +13620,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -14073,15 +13721,6 @@
       "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
     },
     "node_modules/string-width": {
       "version": "7.2.0",
@@ -14417,34 +14056,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -14657,18 +14268,6 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
@@ -14872,7 +14471,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -15050,6 +14649,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/validate-npm-package-name": {
@@ -16019,6 +15619,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/wsl-utils": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "db:push": "node --env-file=.env.local node_modules/.bin/drizzle-kit push",
-    "db:studio": "node --env-file=.env.local node_modules/.bin/drizzle-kit studio"
+    "db:push": "drizzle-kit push",
+    "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",

--- a/package.json
+++ b/package.json
@@ -10,12 +10,11 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "db:push": "drizzle-kit push",
-    "db:studio": "drizzle-kit studio"
+    "db:push": "node --env-file=.env.local node_modules/.bin/drizzle-kit push",
+    "db:studio": "node --env-file=.env.local node_modules/.bin/drizzle-kit studio"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
-    "better-sqlite3": "^12.6.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.1",
@@ -23,6 +22,7 @@
     "nanoid": "^5.1.6",
     "next": "16.1.6",
     "pdf-parse": "^2.4.5",
+    "postgres": "^3.4.8",
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
@@ -34,7 +34,6 @@
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
-    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/app/(dashboard)/error.tsx
+++ b/src/app/(dashboard)/error.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[400px] gap-4 text-center px-4">
+      <h2 className="text-xl font-semibold">Something went wrong</h2>
+      <p className="text-muted-foreground max-w-md">
+        An error occurred loading this page. Check the server logs for details.
+        {error.digest && (
+          <span className="block mt-1 text-xs text-muted-foreground/60">
+            Digest: {error.digest}
+          </span>
+        )}
+      </p>
+      <Button onClick={reset} variant="outline">
+        Try again
+      </Button>
+    </div>
+  );
+}

--- a/src/app/api/snapshots/__tests__/route.test.ts
+++ b/src/app/api/snapshots/__tests__/route.test.ts
@@ -70,9 +70,11 @@ describe('POST /api/snapshots', () => {
 
   it('returns 409 for duplicate snapshot (same accountId + date)', async () => {
     mockGetAccountById.mockResolvedValue({ id: 'acc-123' });
-    mockCreateSnapshot.mockRejectedValue(
-      new Error('UNIQUE constraint failed: snapshots.account_id, snapshots.date'),
+    const pgError = Object.assign(
+      new Error('duplicate key value violates unique constraint'),
+      { code: '23505' },
     );
+    mockCreateSnapshot.mockRejectedValue(pgError);
     const res = await POST(makeRequest(validBody));
     expect(res.status).toBe(409);
     const json = await res.json();

--- a/src/app/api/snapshots/route.ts
+++ b/src/app/api/snapshots/route.ts
@@ -64,8 +64,8 @@ function isValidSnapshotBody(
 }
 
 function isUniqueConstraintError(err: unknown): boolean {
-  if (err instanceof Error) {
-    return err.message.includes('UNIQUE constraint failed');
+  if (typeof err === 'object' && err !== null && 'code' in err) {
+    return (err as { code: string }).code === '23505';
   }
   return false;
 }

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <html>
+      <body className="flex flex-col items-center justify-center min-h-screen gap-4 text-center px-4">
+        <h2 className="text-xl font-semibold">Something went wrong</h2>
+        <p className="text-muted-foreground max-w-md">
+          An unexpected error occurred.
+          {error.digest && (
+            <span className="block mt-1 text-xs text-muted-foreground/60">
+              Digest: {error.digest}
+            </span>
+          )}
+        </p>
+        <Button onClick={reset} variant="outline">
+          Try again
+        </Button>
+      </body>
+    </html>
+  );
+}

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -1,29 +1,37 @@
 import 'server-only';
-import Database from 'better-sqlite3';
-import { drizzle } from 'drizzle-orm/better-sqlite3';
+import postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
 import * as schema from './schema';
-import path from 'path';
-import fs from 'fs';
 
-const DB_PATH = path.join(process.cwd(), 'data', 'retireview.db');
+type DbInstance = ReturnType<typeof createDbInstance>;
 
-function createDb() {
-  const dir = path.dirname(DB_PATH);
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
+function createDbInstance() {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error('DATABASE_URL environment variable is required');
   }
-
-  const sqlite = new Database(DB_PATH);
-  sqlite.pragma('journal_mode = WAL');
-  return drizzle(sqlite, { schema });
+  const client = postgres(connectionString, { prepare: false });
+  return drizzle(client, { schema });
 }
 
 declare const globalThis: {
-  __db: ReturnType<typeof createDb> | undefined;
+  __db: DbInstance | undefined;
 } & typeof global;
 
-export const db = globalThis.__db ?? createDb();
-
-if (process.env.NODE_ENV !== 'production') {
-  globalThis.__db = db;
+function getDb(): DbInstance {
+  if (!globalThis.__db) {
+    globalThis.__db = createDbInstance();
+  }
+  return globalThis.__db;
 }
+
+export const db = new Proxy({} as DbInstance, {
+  get(_, prop) {
+    const instance = getDb();
+    const value = instance[prop as keyof DbInstance];
+    if (typeof value === 'function') {
+      return value.bind(instance);
+    }
+    return value;
+  },
+});

--- a/src/lib/db/queries/__tests__/snapshots.test.ts
+++ b/src/lib/db/queries/__tests__/snapshots.test.ts
@@ -7,40 +7,51 @@ vi.mock('server-only', () => ({}));
 // Mock nanoid
 vi.mock('nanoid', () => ({ nanoid: () => 'test-id-123' }));
 
-// Mock DB module
-const mockAll = vi.fn();
-const mockRun = vi.fn();
+// Queue of results returned when a query chain is awaited
+const resultQueue: unknown[] = [];
 
-vi.mock('@/lib/db', () => ({
-  db: {
-    select: () => ({
-      from: () => ({
-        where: () => ({
-          orderBy: () => ({
-            limit: () => ({ all: mockAll }),
-            all: mockAll,
-          }),
-          all: mockAll,
-        }),
-      }),
-    }),
-    insert: () => ({
-      values: () => ({ run: mockRun }),
-    }),
-  },
-}));
+vi.mock('@/lib/db', () => {
+  // Every chain method returns the chain; awaiting resolves the next queued result
+  function makeChain(): Record<string, unknown> {
+    const chain: Record<string, unknown> = {};
+    const self = (): Record<string, unknown> => chain;
+    chain.from = self;
+    chain.where = self;
+    chain.orderBy = self;
+    chain.limit = self;
+    chain.values = self;
+    chain.set = self;
+    chain.then = (
+      resolve: (v: unknown) => unknown,
+      reject?: (e: unknown) => unknown,
+    ) => {
+      const value = resultQueue.shift();
+      return Promise.resolve(value).then(resolve, reject);
+    };
+    return chain;
+  }
+
+  return {
+    db: {
+      select: () => makeChain(),
+      insert: () => makeChain(),
+      update: () => makeChain(),
+    },
+  };
+});
 
 describe('createSnapshot', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resultQueue.length = 0;
   });
 
   it('sets gains to 0 for first snapshot (no previous)', async () => {
-    // First call: getLatestSnapshot returns empty (no previous)
-    // Second call: select after insert returns the created row
-    mockAll
-      .mockReturnValueOnce([]) // getLatestSnapshot → no previous
-      .mockReturnValueOnce([
+    // Queue: getLatestSnapshot → empty, insert → void, select-by-id → row
+    resultQueue.push(
+      [], // getLatestSnapshot → no previous
+      undefined, // insert
+      [
         {
           id: 'test-id-123',
           userId: 'user-1',
@@ -51,7 +62,8 @@ describe('createSnapshot', () => {
           gains: 0,
           source: 'manual',
         },
-      ]);
+      ],
+    );
 
     const { createSnapshot } = await import('../snapshots');
     const result = await createSnapshot('user-1', {
@@ -62,9 +74,6 @@ describe('createSnapshot', () => {
     });
 
     expect(result).not.toBeNull();
-    // Verify gains=0 was passed to insert
-    const insertCall = mockRun.mock.calls[0];
-    expect(insertCall).toBeDefined();
     expect(result?.gains).toBe(0);
   });
 
@@ -78,8 +87,8 @@ describe('createSnapshot', () => {
       contributions,
     ); // 120000 - 100000 - 5000 = 15000
 
-    mockAll
-      .mockReturnValueOnce([
+    resultQueue.push(
+      [
         {
           id: 'prev-id',
           userId: 'user-1',
@@ -90,8 +99,9 @@ describe('createSnapshot', () => {
           gains: 0,
           source: 'manual',
         },
-      ]) // getLatestSnapshot → has previous
-      .mockReturnValueOnce([
+      ], // getLatestSnapshot → has previous
+      undefined, // insert
+      [
         {
           id: 'test-id-123',
           userId: 'user-1',
@@ -102,7 +112,8 @@ describe('createSnapshot', () => {
           gains: expectedGains,
           source: 'manual',
         },
-      ]);
+      ],
+    );
 
     // Re-import to get fresh module with new mocks
     vi.resetModules();

--- a/src/lib/db/queries/accounts.ts
+++ b/src/lib/db/queries/accounts.ts
@@ -11,12 +11,11 @@ export async function getAccounts(userId: string): Promise<Account[]> {
     .from(accounts)
     .where(
       and(eq(accounts.userId, userId), eq(accounts.isActive, true)),
-    )
-    .all();
+    );
 }
 
 export async function getAccountById(id: string): Promise<Account | null> {
-  const rows = db.select().from(accounts).where(eq(accounts.id, id)).all();
+  const rows = await db.select().from(accounts).where(eq(accounts.id, id));
   return rows[0] ?? null;
 }
 
@@ -25,7 +24,7 @@ export async function createAccount(
   data: { name: string; type: string; institution: string },
 ): Promise<Account | null> {
   const id = nanoid();
-  db.insert(accounts)
+  await db.insert(accounts)
     .values({
       id,
       userId,
@@ -33,14 +32,12 @@ export async function createAccount(
       type: data.type as 'checking' | 'savings' | 'investment' | 'retirement' | 'debt',
       institution: data.institution,
       createdAt: new Date().toISOString(),
-    })
-    .run();
+    });
   return getAccountById(id);
 }
 
 export async function softDeleteAccount(id: string): Promise<void> {
-  db.update(accounts)
+  await db.update(accounts)
     .set({ isActive: false })
-    .where(eq(accounts.id, id))
-    .run();
+    .where(eq(accounts.id, id));
 }

--- a/src/lib/db/queries/imports.ts
+++ b/src/lib/db/queries/imports.ts
@@ -8,19 +8,17 @@ export async function getImportHistory(): Promise<ImportLog[]> {
   return db
     .select()
     .from(importLog)
-    .orderBy(desc(importLog.importedAt))
-    .all();
+    .orderBy(desc(importLog.importedAt));
 }
 
 export async function createImportEntry(
   data: NewImportLog,
 ): Promise<ImportLog | null> {
-  db.insert(importLog).values(data).run();
-  const rows = db
+  await db.insert(importLog).values(data);
+  const rows = await db
     .select()
     .from(importLog)
-    .where(eq(importLog.id, data.id))
-    .all();
+    .where(eq(importLog.id, data.id));
   return rows[0] ?? null;
 }
 
@@ -33,5 +31,5 @@ export async function updateImportStatus(
   if (recordCount !== undefined) {
     updates.recordsCreated = recordCount;
   }
-  db.update(importLog).set(updates).where(eq(importLog.id, id)).run();
+  await db.update(importLog).set(updates).where(eq(importLog.id, id));
 }

--- a/src/lib/db/queries/retirement-settings.ts
+++ b/src/lib/db/queries/retirement-settings.ts
@@ -8,11 +8,10 @@ import type { RetirementSettings } from '@/types';
 export async function getRetirementSettings(
   userId: string,
 ): Promise<RetirementSettings | null> {
-  const rows = db
+  const rows = await db
     .select()
     .from(retirementSettings)
-    .where(eq(retirementSettings.userId, userId))
-    .all();
+    .where(eq(retirementSettings.userId, userId));
   return rows[0] ?? null;
 }
 
@@ -29,19 +28,17 @@ export async function upsertRetirementSettings(
   const now = new Date().toISOString();
 
   if (existing) {
-    db.update(retirementSettings)
+    await db.update(retirementSettings)
       .set({ ...data, updatedAt: now })
-      .where(eq(retirementSettings.id, existing.id))
-      .run();
+      .where(eq(retirementSettings.id, existing.id));
   } else {
-    db.insert(retirementSettings)
+    await db.insert(retirementSettings)
       .values({
         id: nanoid(),
         userId,
         ...data,
         updatedAt: now,
-      })
-      .run();
+      });
   }
 
   return getRetirementSettings(userId);

--- a/src/lib/db/queries/snapshots.ts
+++ b/src/lib/db/queries/snapshots.ts
@@ -13,8 +13,7 @@ export async function getSnapshotsByAccount(
     .select()
     .from(snapshots)
     .where(eq(snapshots.accountId, accountId))
-    .orderBy(desc(snapshots.date))
-    .all();
+    .orderBy(desc(snapshots.date));
 }
 
 export async function getAllSnapshots(userId: string): Promise<Snapshot[]> {
@@ -22,20 +21,18 @@ export async function getAllSnapshots(userId: string): Promise<Snapshot[]> {
     .select()
     .from(snapshots)
     .where(eq(snapshots.userId, userId))
-    .orderBy(desc(snapshots.date))
-    .all();
+    .orderBy(desc(snapshots.date));
 }
 
 export async function getLatestSnapshot(
   accountId: string,
 ): Promise<Snapshot | null> {
-  const rows = db
+  const rows = await db
     .select()
     .from(snapshots)
     .where(eq(snapshots.accountId, accountId))
     .orderBy(desc(snapshots.date))
-    .limit(1)
-    .all();
+    .limit(1);
   return rows[0] ?? null;
 }
 
@@ -56,11 +53,10 @@ export async function findDuplicateSnapshot(
   accountId: string,
   date: string,
 ): Promise<Snapshot | null> {
-  const rows = db
+  const rows = await db
     .select()
     .from(snapshots)
-    .where(and(eq(snapshots.accountId, accountId), eq(snapshots.date, date)))
-    .all();
+    .where(and(eq(snapshots.accountId, accountId), eq(snapshots.date, date)));
   return rows[0] ?? null;
 }
 
@@ -80,7 +76,7 @@ export async function createSnapshot(
     : 0;
 
   const id = nanoid();
-  db.insert(snapshots)
+  await db.insert(snapshots)
     .values({
       id,
       userId,
@@ -90,9 +86,8 @@ export async function createSnapshot(
       contributions: data.contributions,
       gains,
       source: data.source ?? 'manual',
-    })
-    .run();
+    });
 
-  const rows = db.select().from(snapshots).where(eq(snapshots.id, id)).all();
+  const rows = await db.select().from(snapshots).where(eq(snapshots.id, id));
   return rows[0] ?? null;
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1,6 +1,13 @@
-import { sqliteTable, text, integer, real, uniqueIndex } from 'drizzle-orm/sqlite-core';
+import {
+  pgTable,
+  text,
+  integer,
+  boolean,
+  doublePrecision,
+  uniqueIndex,
+} from 'drizzle-orm/pg-core';
 
-export const accounts = sqliteTable('accounts', {
+export const accounts = pgTable('accounts', {
   id: text('id').primaryKey(),
   userId: text('user_id').notNull(),
   name: text('name').notNull(),
@@ -8,11 +15,11 @@ export const accounts = sqliteTable('accounts', {
     enum: ['checking', 'savings', 'investment', 'retirement', 'debt'],
   }).notNull(),
   institution: text('institution').notNull(),
-  isActive: integer('is_active', { mode: 'boolean' }).notNull().default(true),
+  isActive: boolean('is_active').notNull().default(true),
   createdAt: text('created_at').notNull(),
 });
 
-export const snapshots = sqliteTable('snapshots', {
+export const snapshots = pgTable('snapshots', {
   id: text('id').primaryKey(),
   userId: text('user_id').notNull(),
   accountId: text('account_id')
@@ -29,17 +36,17 @@ export const snapshots = sqliteTable('snapshots', {
   uniqueIndex('snapshots_account_date_idx').on(table.accountId, table.date),
 ]);
 
-export const retirementSettings = sqliteTable('retirement_settings', {
+export const retirementSettings = pgTable('retirement_settings', {
   id: text('id').primaryKey(),
   userId: text('user_id').notNull(),
   annualSpendTarget: integer('annual_spend_target').notNull(),
-  withdrawalRate: real('withdrawal_rate').notNull().default(0.04),
+  withdrawalRate: doublePrecision('withdrawal_rate').notNull().default(0.04),
   targetRetirementAge: integer('target_retirement_age').notNull(),
   currentAge: integer('current_age').notNull(),
   updatedAt: text('updated_at').notNull(),
 });
 
-export const importLog = sqliteTable('import_log', {
+export const importLog = pgTable('import_log', {
   id: text('id').primaryKey(),
   userId: text('user_id').notNull(),
   source: text('source').notNull(),


### PR DESCRIPTION
## Summary
- **Swap deps**: `better-sqlite3` → `postgres` (postgres-js, pure JS, zero native deps)
- **Rewrite schema**: `sqliteTable` → `pgTable` with native `boolean` and `doublePrecision` types
- **Rewrite DB connection**: lazy Proxy pattern with `prepare: false` for Supabase PgBouncer pooler — builds succeed without `DATABASE_URL` at build time
- **Update all 4 query files**: remove `.all()`/`.run()` (SQLite-specific), add proper `await`
- **Fix unique constraint check**: SQLite error message → PostgreSQL error code `23505`
- **Update Drizzle config**: `dialect: 'postgresql'`, uses `DATABASE_URL_DIRECT` for schema push
- **Update test mocks**: queue-based thenable mock matching postgres-js async driver
- **Add `.env.example`** and update `db:push`/`db:studio` scripts with `--env-file`

## Verification
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 53/53 passing
- [x] `npm run build` — production build succeeds
- [x] `npm run db:push` — tables created in Supabase
- [x] `npm run dev` — all API endpoints return correct responses
- [x] Deployed to Vercel — https://retiredash.vercel.app (live, APIs working)

## Test plan
- [ ] Verify all pages load on deployed URL
- [ ] Create an account and snapshot via the UI
- [ ] Confirm data persists across page refreshes (Supabase, not local SQLite)
- [ ] Test PDF import flow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)